### PR TITLE
performance optimization & code modernization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,10 @@ exclude = [
 [dependencies]
 
 [dev-dependencies]
-ring = "0.12.1"
+ring = "0.16.1"
 arrayref = "0.3.2"
+criterion = "0.3"
+
+[[bench]]
+name = "benchmarks"
+harness = false

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -1,0 +1,22 @@
+extern crate cdc;
+extern crate criterion;
+
+use cdc::{Rabin64, RollingHash64};
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+pub fn slide_benchmarks(c: &mut Criterion) {
+    for i in [1_000, 10_000, 100_000] {
+        c.bench_function(&format!("slide {}x", i), |b| {
+            let data: u8 = 16; //arbitrary value
+            b.iter(|| {
+                let mut rabin = Rabin64::new(5);
+                for _ in 0..i {
+                    rabin.slide(&data)
+                }
+            })
+        });
+    }
+}
+
+criterion_group!(benches, slide_benchmarks);
+criterion_main!(benches);

--- a/examples/chunk.rs
+++ b/examples/chunk.rs
@@ -15,7 +15,7 @@ fn my_default_predicate(x: u64) -> bool {
 }
 
 fn chunk_file<S: Into<String>>(path: S) -> io::Result<()> {
-    let f = try!(File::open(path.into()));
+    let f = File::open(path.into())?;
     let stream_length = f.metadata().unwrap().len();
     let reader: BufReader<File> = BufReader::new(f);
     let byte_iter = reader.bytes().map(|b| b.unwrap());

--- a/examples/chunk.rs
+++ b/examples/chunk.rs
@@ -1,11 +1,11 @@
 extern crate cdc;
 
-use std::u64;
-use std::cmp::{min, max};
+use std::cmp::{max, min};
+use std::fs::File;
 use std::io;
 use std::io::prelude::*;
 use std::io::BufReader;
-use std::fs::File;
+use std::u64;
 
 use cdc::*;
 
@@ -31,7 +31,10 @@ fn chunk_file<S: Into<String>>(path: S) -> io::Result<()> {
     let expected_size = 1 << 13;
     let mut size_variance = 0;
     for chunk in chunk_iter {
-        println!("Index: {}, size: {:6}, separator_hash: {:016x}", chunk.index, chunk.size, chunk.separator_hash);
+        println!(
+            "Index: {}, size: {:6}, separator_hash: {:016x}",
+            chunk.index, chunk.size, chunk.separator_hash
+        );
         nb_chunk += 1;
         total_size += chunk.size;
         smallest_size = min(smallest_size, chunk.size);
@@ -39,16 +42,22 @@ fn chunk_file<S: Into<String>>(path: S) -> io::Result<()> {
         size_variance += (chunk.size as i64 - expected_size as i64).pow(2);
     }
 
-    println!("{} chunks with an average size of {} bytes.", nb_chunk, total_size / nb_chunk);
+    println!(
+        "{} chunks with an average size of {} bytes.",
+        nb_chunk,
+        total_size / nb_chunk
+    );
     println!("Expected chunk size: {} bytes", expected_size);
     println!("Smallest chunk: {} bytes.", smallest_size);
     println!("Largest chunk: {} bytes.", largest_size);
-    println!("Standard size deviation: {} bytes.",
-        (size_variance as f64 / nb_chunk as f64).sqrt() as u64);
+    println!(
+        "Standard size deviation: {} bytes.",
+        (size_variance as f64 / nb_chunk as f64).sqrt() as u64
+    );
 
-	Ok(())
+    Ok(())
 }
 
 fn main() {
-	chunk_file("myLargeFile.bin").unwrap();
+    chunk_file("myLargeFile.bin").unwrap();
 }

--- a/examples/separator.rs
+++ b/examples/separator.rs
@@ -8,7 +8,7 @@ use std::fs::File;
 use cdc::*;
 
 fn chunk_file<S: Into<String>>(path: S) -> io::Result<()> {
-    let f = try!(File::open(path.into()));
+    let f = File::open(path.into())?;
     let reader: BufReader<File> = BufReader::new(f);
     let byte_iter = reader.bytes().map(|b| b.unwrap());
 

--- a/examples/separator.rs
+++ b/examples/separator.rs
@@ -1,9 +1,9 @@
 extern crate cdc;
 
+use std::fs::File;
 use std::io;
 use std::io::prelude::*;
 use std::io::BufReader;
-use std::fs::File;
 
 use cdc::*;
 
@@ -19,9 +19,9 @@ fn chunk_file<S: Into<String>>(path: S) -> io::Result<()> {
     }
     println!("We found {} separators.", nb_separator);
 
-	Ok(())
+    Ok(())
 }
 
 fn main() {
-	chunk_file("myLargeFile.bin").unwrap();
+    chunk_file("myLargeFile.bin").unwrap();
 }

--- a/examples/tree01.rs
+++ b/examples/tree01.rs
@@ -4,11 +4,11 @@ use cdc::*;
 
 type IntHash = u32;
 
-static mut hash_id: IntHash = 0;
+static mut HASH_ID: IntHash = 0;
 fn get_new_hash_id() -> IntHash {
     unsafe {
-        let id = hash_id;
-        hash_id += 1;
+        let id = HASH_ID;
+        HASH_ID += 1;
         id
     }
 }
@@ -29,7 +29,7 @@ fn main() {
     });
 
     unsafe {
-        hash_id = levels.len() as IntHash;
+        HASH_ID = levels.len() as IntHash;
     }
 
     for node in NodeIter::new(hashed_chunk_it, my_new_node, 0) {

--- a/examples/tree01.rs
+++ b/examples/tree01.rs
@@ -17,15 +17,16 @@ fn my_new_node(level: usize, children: &Vec<IntHash>) -> Node<IntHash> {
     Node {
         hash: get_new_hash_id(),
         level: level,
-        children: children.clone()
+        children: children.clone(),
     }
 }
 
 fn main() {
     let levels = [0usize, 0, 1, 0, 1, 1, 2, 1, 0, 1, 0, 1];
     //let levels = [1usize, 1, 1, 1, 1, 1, 1, 1, 0, 1, 0, 1];
-    let hashed_chunk_it = levels.iter().enumerate().map(|(index, level)| {
-        HashedChunk {hash: index as IntHash, level: *level}
+    let hashed_chunk_it = levels.iter().enumerate().map(|(index, level)| HashedChunk {
+        hash: index as IntHash,
+        level: *level,
     });
 
     unsafe {

--- a/examples/tree02.rs
+++ b/examples/tree02.rs
@@ -27,15 +27,15 @@ impl<R: Read> DigestReader<R> {
 
 impl<R: Read> Read for DigestReader<R> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        let size = try!(self.inner.read(buf));
+        let size = self.inner.read(buf)?;
         self.digest.update(&buf[0..size]);
         Ok(size)
     }
 }
 
 fn file_chunk_reader(path: &String, chunk: &Chunk) -> io::Result<io::Take<BufReader<File>>> {
-    let mut file = try!(File::open(path));
-    try!(file.seek(SeekFrom::Start(chunk.index)));
+    let mut file = File::open(path)?;
+    file.seek(SeekFrom::Start(chunk.index))?;
     Ok(BufReader::new(file).take(chunk.size))
 }
 
@@ -59,7 +59,7 @@ fn new_hash_node(level: usize, children: &Vec<Hash256>) -> Node<Hash256> {
 
 fn chunk_file(path: &String) -> io::Result<()> {
     // Opens the file and gets the byte_iter.
-    let f = try!(File::open(path));
+    let f = File::open(path)?;
     let stream_length = f.metadata().unwrap().len();
     let reader: BufReader<File> = BufReader::new(f);
     let byte_iter = reader.bytes().map(|b| b.unwrap());

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -1,4 +1,4 @@
-use super::{Separator};
+use super::Separator;
 
 pub struct Chunk {
     pub index: u64,
@@ -12,7 +12,7 @@ pub struct ChunkIter<Iter> {
     last_separator_index: u64,
 }
 
-impl<Iter: Iterator<Item=Separator>> ChunkIter<Iter> {
+impl<Iter: Iterator<Item = Separator>> ChunkIter<Iter> {
     pub fn new(iter: Iter, stream_length: u64) -> ChunkIter<Iter> {
         ChunkIter {
             separators: iter,
@@ -22,7 +22,7 @@ impl<Iter: Iterator<Item=Separator>> ChunkIter<Iter> {
     }
 }
 
-impl<Iter: Iterator<Item=Separator>> Iterator for ChunkIter<Iter> {
+impl<Iter: Iterator<Item = Separator>> Iterator for ChunkIter<Iter> {
     type Item = Chunk;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -35,7 +35,7 @@ impl<Iter: Iterator<Item=Separator>> Iterator for ChunkIter<Iter> {
                     size: chunk_size,
                     separator_hash: separator.hash,
                 });
-            },
+            }
             None => {
                 let chunk_size = self.stream_length - self.last_separator_index;
                 self.last_separator_index = self.stream_length;
@@ -45,8 +45,7 @@ impl<Iter: Iterator<Item=Separator>> Iterator for ChunkIter<Iter> {
                         size: chunk_size,
                         separator_hash: 0, // any value is ok, last chunk of the stream.
                     });
-                }
-                else {
+                } else {
                     return None;
                 }
             }

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -16,7 +16,7 @@ impl<Iter: Iterator<Item = Separator>> ChunkIter<Iter> {
     pub fn new(iter: Iter, stream_length: u64) -> ChunkIter<Iter> {
         ChunkIter {
             separators: iter,
-            stream_length: stream_length,
+            stream_length,
             last_separator_index: 0,
         }
     }
@@ -30,23 +30,23 @@ impl<Iter: Iterator<Item = Separator>> Iterator for ChunkIter<Iter> {
             Some(separator) => {
                 let chunk_size = separator.index - self.last_separator_index;
                 self.last_separator_index = separator.index;
-                return Some(Chunk {
+                Some(Chunk {
                     index: self.last_separator_index,
                     size: chunk_size,
                     separator_hash: separator.hash,
-                });
+                })
             }
             None => {
                 let chunk_size = self.stream_length - self.last_separator_index;
                 self.last_separator_index = self.stream_length;
                 if chunk_size > 0 {
-                    return Some(Chunk {
+                    Some(Chunk {
                         index: self.last_separator_index,
                         size: chunk_size,
                         separator_hash: 0, // any value is ok, last chunk of the stream.
-                    });
+                    })
                 } else {
-                    return None;
+                    None
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,11 @@
+mod chunk;
 mod polynom;
 mod rolling_hash;
 mod separator;
-mod chunk;
 mod tree;
 
-pub use polynom::{Polynom, Polynom64};
-pub use rolling_hash::{RollingHash64, Rabin64};
-pub use separator::{Separator, SeparatorIter, HashToLevel};
 pub use chunk::{Chunk, ChunkIter};
+pub use polynom::{Polynom, Polynom64};
+pub use rolling_hash::{Rabin64, RollingHash64};
+pub use separator::{HashToLevel, Separator, SeparatorIter};
 pub use tree::{HashedChunk, Node, NodeIter};

--- a/src/polynom.rs
+++ b/src/polynom.rs
@@ -9,14 +9,7 @@ pub type Polynom64 = u64;
 impl Polynom for Polynom64 {
     // The degree of the polynom.
     fn degree(&self) -> i32 {
-        for i in (0..63).rev() {
-            if *self >= ((1 as Self) << i) {
-                return i;
-            }
-        }
-
-        // The "0" polynom has a degree -1.
-        return -1;
+        63 - self.leading_zeros() as i32
     }
 
     fn modulo(&self, m: &Self) -> Self {

--- a/src/polynom.rs
+++ b/src/polynom.rs
@@ -18,7 +18,7 @@ impl Polynom for Polynom64 {
             p ^= m << (p.degree() - m.degree());
         }
 
-        return p;
+        p
     }
 }
 

--- a/src/rolling_hash.rs
+++ b/src/rolling_hash.rs
@@ -34,13 +34,13 @@ pub const MOD_POLYNOM: Polynom64 = 0x3DA3358B4DC173;
 impl Rabin64 {
     pub fn calculate_out_table(window_size: usize, mod_polynom: &Polynom64) -> [Polynom64; 256] {
         let mut out_table = [0; 256];
-        for b in 0..256 {
+        for (b, elem) in out_table.iter_mut().enumerate() {
             let mut hash = (b as Polynom64).modulo(mod_polynom);
             for _ in 0..window_size - 1 {
                 hash <<= 8;
                 hash = hash.modulo(mod_polynom);
             }
-            out_table[b] = hash;
+            *elem = hash;
         }
 
         out_table
@@ -49,9 +49,9 @@ impl Rabin64 {
     pub fn calculate_mod_table(mod_polynom: &Polynom64) -> [Polynom64; 256] {
         let mut mod_table = [0; 256];
         let k = mod_polynom.degree();
-        for b in 0..256 {
+        for (b, elem) in mod_table.iter_mut().enumerate() {
             let p: Polynom64 = (b as Polynom64) << k;
-            mod_table[b] = p.modulo(mod_polynom) | p;
+            *elem = p.modulo(mod_polynom) | p;
         }
 
         mod_table
@@ -64,16 +64,15 @@ impl Rabin64 {
     pub fn new_with_polynom(window_size_nb_bits: u32, mod_polynom: &Polynom64) -> Rabin64 {
         let window_size = 1 << window_size_nb_bits;
 
-        let mut window_data = Vec::with_capacity(window_size);
-        window_data.resize(window_size, 0);
+        let window_data = vec![0; window_size];
 
         Rabin64 {
-            window_size: window_size,
+            window_size,
             window_size_mask: window_size - 1,
             polynom_shift: mod_polynom.degree() - 8,
             out_table: Self::calculate_out_table(window_size, mod_polynom),
             mod_table: Self::calculate_mod_table(mod_polynom),
-            window_data: window_data,
+            window_data,
             window_index: 0,
             hash: 0,
         }

--- a/src/rolling_hash.rs
+++ b/src/rolling_hash.rs
@@ -2,9 +2,9 @@ use super::{Polynom, Polynom64};
 
 pub trait RollingHash64 {
     fn reset(&mut self);
-    fn prefill_window<I>(&mut self, &mut I) -> usize where I: Iterator<Item=u8>;
-    fn reset_and_prefill_window<I>(&mut self, &mut I) -> usize where I: Iterator<Item=u8>;
-    fn slide(&mut self, &u8);
+    fn prefill_window<I>(&mut self, iter: &mut I) -> usize where I: Iterator<Item=u8>;
+    fn reset_and_prefill_window<I>(&mut self, iter: &mut I) -> usize where I: Iterator<Item=u8>;
+    fn slide(&mut self, byte: &u8);
     fn get_hash(&self) -> &Polynom64;
 }
 

--- a/src/separator.rs
+++ b/src/separator.rs
@@ -1,4 +1,4 @@
-use super::{RollingHash64, Rabin64};
+use super::{Rabin64, RollingHash64};
 
 pub struct Separator {
     pub index: u64,
@@ -12,7 +12,10 @@ pub struct SeparatorIter<I, F> {
     index: u64,
 }
 
-impl<I> SeparatorIter<I, fn(u64) -> bool> where I: Iterator<Item=u8> {
+impl<I> SeparatorIter<I, fn(u64) -> bool>
+where
+    I: Iterator<Item = u8>,
+{
     pub fn new(iter: I) -> SeparatorIter<I, fn(u64) -> bool> {
         // window_size: 1 << 6 == 64 bytes
         let separator_size_nb_bits = 6;
@@ -27,10 +30,16 @@ impl<I> SeparatorIter<I, fn(u64) -> bool> where I: Iterator<Item=u8> {
     }
 }
 
-impl<I, F> SeparatorIter<I, F> where I: Iterator<Item=u8>, F: Fn(u64) -> bool {
-    pub fn custom_new(mut iter: I,
+impl<I, F> SeparatorIter<I, F>
+where
+    I: Iterator<Item = u8>,
+    F: Fn(u64) -> bool,
+{
+    pub fn custom_new(
+        mut iter: I,
         separator_size_nb_bits: u32,
-        predicate: F) -> SeparatorIter<I, F> {
+        predicate: F,
+    ) -> SeparatorIter<I, F> {
         let mut rabin = Rabin64::new(separator_size_nb_bits);
         let index = rabin.reset_and_prefill_window(&mut iter) as u64;
 
@@ -43,7 +52,11 @@ impl<I, F> SeparatorIter<I, F> where I: Iterator<Item=u8>, F: Fn(u64) -> bool {
     }
 }
 
-impl<I, F> Iterator for SeparatorIter<I, F> where I: Iterator<Item=u8>, F: Fn(u64) -> bool {
+impl<I, F> Iterator for SeparatorIter<I, F>
+where
+    I: Iterator<Item = u8>,
+    F: Fn(u64) -> bool,
+{
     type Item = Separator;
 
     #[inline]
@@ -52,7 +65,10 @@ impl<I, F> Iterator for SeparatorIter<I, F> where I: Iterator<Item=u8>, F: Fn(u6
             self.rabin.slide(&byte);
             self.index += 1;
             if (self.predicate)(self.rabin.hash) {
-                let separator = Separator {index: self.index, hash: self.rabin.hash};
+                let separator = Separator {
+                    index: self.index,
+                    hash: self.rabin.hash,
+                };
 
                 // Note: We skip subsequent separators which may overlap the current one.
                 self.index += self.rabin.reset_and_prefill_window(&mut self.iter) as u64;
@@ -124,5 +140,4 @@ mod tests {
             assert_eq!(converter.to_level((9u64 << n) - 1), 4);
         }
     }
-
 }

--- a/src/separator.rs
+++ b/src/separator.rs
@@ -44,10 +44,10 @@ where
         let index = rabin.reset_and_prefill_window(&mut iter) as u64;
 
         SeparatorIter {
-            iter: iter,
-            predicate: predicate,
-            rabin: rabin,
-            index: index,
+            iter,
+            predicate,
+            rabin,
+            index,
         }
     }
 }
@@ -95,8 +95,8 @@ impl HashToLevel {
 
     pub fn custom_new(lvl0_nb_bits: u32, lvlup_nb_bits: u32) -> HashToLevel {
         HashToLevel {
-            lvl0_nb_bits: lvl0_nb_bits,
-            lvlup_nb_bits: lvlup_nb_bits,
+            lvl0_nb_bits,
+            lvlup_nb_bits,
             lvlup_bitmask: (1u64 << lvlup_nb_bits) - 1,
         }
     }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -9,7 +9,7 @@ pub struct HashedChunk<H> {
 
 #[derive(Debug)]
 pub struct Node<H> {
-    pub hash: H,  // The hash acting as the ID of this node.
+    pub hash: H, // The hash acting as the ID of this node.
     pub level: usize,
     pub children: Vec<H>,
 }
@@ -22,13 +22,15 @@ pub struct NodeIter<I, F, H> {
 
     // Internal state
     level_hashes: Vec<Vec<H>>, // level_hashes[level] -> Vec<H>
-    out_buffer: Vec<Node<H>>, // Fifo
+    out_buffer: Vec<Node<H>>,  // Fifo
 }
 
-impl<I, F, H> NodeIter<I, F, H> where
-        I: Iterator<Item=HashedChunk<H>>,
-        F: Fn(usize, &Vec<H>) -> Node<H>,
-        H: Copy {
+impl<I, F, H> NodeIter<I, F, H>
+where
+    I: Iterator<Item = HashedChunk<H>>,
+    F: Fn(usize, &Vec<H>) -> Node<H>,
+    H: Copy,
+{
     pub fn new(iter: I, new_node: F, max_node_children: usize) -> NodeIter<I, F, H> {
         NodeIter {
             chunks: iter,
@@ -61,7 +63,7 @@ impl<I, F, H> NodeIter<I, F, H> where
                 let level_up_hash = self.level_hashes[level][0];
                 self.level_hashes[level].clear();
                 self.add_at_level(level + 1, level_up_hash);
-            },
+            }
             _ => {
                 let node = (self.new_node)(level, &self.level_hashes[level]);
                 let level_up_hash = node.hash;
@@ -77,13 +79,14 @@ impl<I, F, H> NodeIter<I, F, H> where
             self.output_level(level);
         }
     }
-
 }
 
-impl<I, F, H> Iterator for NodeIter<I, F, H> where
-        I: Iterator<Item=HashedChunk<H>>,
-        F: Fn(usize, &Vec<H>) -> Node<H>,
-        H: Copy {
+impl<I, F, H> Iterator for NodeIter<I, F, H>
+where
+    I: Iterator<Item = HashedChunk<H>>,
+    F: Fn(usize, &Vec<H>) -> Node<H>,
+    H: Copy,
+{
     type Item = Node<H>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -96,16 +99,14 @@ impl<I, F, H> Iterator for NodeIter<I, F, H> where
                 self.add_at_level(0, chunk.hash);
                 self.output_levels(chunk.level);
                 self.out_buffer.reverse();
-            }
-            else {
+            } else {
                 let len = self.level_hashes.len();
                 if len > 0 {
                     // Flush the remaining hashes.
                     self.output_levels(len);
                     self.level_hashes.clear();
                     self.out_buffer.reverse();
-                }
-                else {
+                } else {
                     return None;
                 }
             }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -34,7 +34,7 @@ where
     pub fn new(iter: I, new_node: F, max_node_children: usize) -> NodeIter<I, F, H> {
         NodeIter {
             chunks: iter,
-            new_node: new_node,
+            new_node,
             max_children: max_node_children,
             level_hashes: Vec::with_capacity(16),
             out_buffer: Vec::with_capacity(16),
@@ -57,7 +57,7 @@ where
 
     fn output_level(&mut self, level: usize) {
         match self.level_hashes[level].len() {
-            0 => return, // Don't output empty nodes.
+            0 => {} // Don't output empty nodes.
             1 => {
                 // Don't output a node with only 1 hash, move it to the upper level.
                 let level_up_hash = self.level_hashes[level][0];
@@ -91,7 +91,7 @@ where
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
-            if self.out_buffer.len() > 0 {
+            if !self.out_buffer.is_empty() {
                 return self.out_buffer.pop();
             }
 


### PR DESCRIPTION
The first two commits are a performance optimization of the computation Polynom.degree() including a criterion benchmark to test it. The benchmark results of the change are:
```
slide 1000x             time:   [107.62 us 108.43 us 109.41 us]                        
                        change: [-89.783% -89.651% -89.511%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) high mild
  8 (8.00%) high severe

slide 10000x            time:   [153.83 us 154.36 us 155.03 us]                         
                        change: [-85.824% -85.697% -85.592%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  3 (3.00%) high mild
  7 (7.00%) high severe

slide 100000x           time:   [627.94 us 633.68 us 639.98 us]                          
                        change: [-60.342% -59.710% -59.218%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 17 outliers among 100 measurements (17.00%)
  6 (6.00%) high mild
  11 (11.00%) high severe
```
closes #2

In the other commits I tried to modernize the code such that warnings, code formatting and (most) clippy results are fixed. Feel free to omit these three commits.
I'm not sure if the clippy-hinted improvements in `rolling_hash.rs` may give a small additional performance gain. But it might be also within statistical noise. The results are:
```
slide 1000x             time:   [106.70 us 107.83 us 109.07 us]                        
                        change: [-2.5015% -1.2324% +0.1788%] (p = 0.08 > 0.05)
                        No change in performance detected.
Found 17 outliers among 100 measurements (17.00%)
  5 (5.00%) high mild
  12 (12.00%) high severe

slide 10000x            time:   [151.65 us 152.65 us 153.87 us]                         
                        change: [-4.5617% -2.9682% -1.7269%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  2 (2.00%) high mild
  6 (6.00%) high severe

slide 100000x           time:   [607.56 us 608.77 us 610.50 us]                          
                        change: [-3.0764% -2.1333% -0.9672%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 14 outliers among 100 measurements (14.00%)
```