### PR TITLE
fix compiler errors

### DIFF
--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -2,7 +2,7 @@ extern crate cdc;
 extern crate criterion;
 
 use cdc::{Rabin64, RollingHash64};
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 
 pub fn slide_benchmarks(c: &mut Criterion) {
     for i in [1_000, 10_000, 100_000] {
@@ -11,7 +11,7 @@ pub fn slide_benchmarks(c: &mut Criterion) {
             b.iter(|| {
                 let mut rabin = Rabin64::new(5);
                 for _ in 0..i {
-                    rabin.slide(&data)
+                    rabin.slide(data)
                 }
             })
         });

--- a/src/rolling_hash.rs
+++ b/src/rolling_hash.rs
@@ -8,7 +8,7 @@ pub trait RollingHash64 {
     fn reset_and_prefill_window<I>(&mut self, iter: &mut I) -> usize
     where
         I: Iterator<Item = u8>;
-    fn slide(&mut self, byte: &u8);
+    fn slide(&mut self, byte: u8);
     fn get_hash(&self) -> &Polynom64;
 }
 
@@ -108,7 +108,7 @@ impl RollingHash64 for Rabin64 {
         for _ in 0..self.window_size - 1 {
             match iter.next() {
                 Some(b) => {
-                    self.slide(&b);
+                    self.slide(b);
                     nb_bytes_read += 1;
                 }
                 None => break,
@@ -154,16 +154,16 @@ impl RollingHash64 for Rabin64 {
     }
 
     #[inline]
-    fn slide(&mut self, byte: &u8) {
+    fn slide(&mut self, byte: u8) {
         // Take the old value out of the window and the hash.
         let out_value = self.window_data[self.window_index];
         self.hash ^= self.out_table[out_value as usize];
 
         // Put the new value in the window and in the hash.
-        self.window_data[self.window_index] = *byte;
+        self.window_data[self.window_index] = byte;
         let mod_index = (self.hash >> self.polynom_shift) & 255;
         self.hash <<= 8;
-        self.hash |= *byte as Polynom64;
+        self.hash |= byte as Polynom64;
         self.hash ^= self.mod_table[mod_index as usize];
 
         // Move the windowIndex to the next position.
@@ -216,7 +216,7 @@ mod tests {
             rabin1.reset();
             rabin1.hash_block(block, &MOD_POLYNOM);
 
-            rabin2.slide(&data[i]);
+            rabin2.slide(data[i]);
 
             //println!("{:02} {:02} {:016x} {:016x} {:?}", i, block.len(), rabin1.hash, rabin2.hash, block);
             assert_eq!(rabin1.hash, rabin2.hash);

--- a/src/separator.rs
+++ b/src/separator.rs
@@ -62,7 +62,7 @@ where
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         while let Some(byte) = self.iter.next() {
-            self.rabin.slide(&byte);
+            self.rabin.slide(byte);
             self.index += 1;
             if (self.predicate)(self.rabin.hash) {
                 let separator = Separator {


### PR DESCRIPTION
Seems the compiler gets stricter about types.
I'm getting the following errors when trying to publish my dependent project:
```
error[E0053]: method `slide` has an incompatible type for trait                                                                                                             
   --> /home/alex-dev/.cargo/registry/src/github.com-1ecc6299db9ec823/cdc-0.1.1/src/rolling_hash.rs:157:31                                                                  
    |                                                                                                                                                                       
157 |     fn slide(&mut self, byte: u8) {                                                                                                                                   
    |                               ^^                                                                                                                                      
    |                               |                                                                                                                                       
    |                               expected `&u8`, found `u8`                                                                                                              
    |                               help: change the parameter type to match the trait: `&u8`                                                                               
    |                                                                                                                                                                       
note: type in trait                                                                                                                                                         
   --> /home/alex-dev/.cargo/registry/src/github.com-1ecc6299db9ec823/cdc-0.1.1/src/rolling_hash.rs:11:31                                                                   
    |                                                                                                                                                                       
11  |     fn slide(&mut self, byte: &u8);                                                                                                                                   
    |                               ^^^                                                                                                                                     
    = note: expected fn pointer `fn(&mut Rabin64, &u8)`                                                                                                                     
               found fn pointer `fn(&mut Rabin64, u8)`
                                           
error[E0308]: mismatched types       
   --> /home/alex-dev/.cargo/registry/src/github.com-1ecc6299db9ec823/cdc-0.1.1/src/rolling_hash.rs:111:32
    |                                                                                                                                                                       
111 |                     self.slide(b);
    |                          ----- ^
    |                          |     |                                                                                                                                      
    |                          |     expected `&u8`, found `u8`
    |                          |     help: consider borrowing here: `&b`
    |                          arguments to this function are incorrect
    |                                                                                 
note: associated function defined here                                                
   --> /home/alex-dev/.cargo/registry/src/github.com-1ecc6299db9ec823/cdc-0.1.1/src/rolling_hash.rs:11:8
    |                         
11  |     fn slide(&mut self, byte: &u8);                                                                                                                                   
    |        ^^^^^         
                                           
error[E0614]: type `u8` cannot be dereferenced
   --> /home/alex-dev/.cargo/registry/src/github.com-1ecc6299db9ec823/cdc-0.1.1/src/rolling_hash.rs:163:47
    |                                                                                 
163 |         self.window_data[self.window_index] = *byte;
    |                                               ^^^^^
```

This PR should fix these errors.