### PR TITLE
Derive clone for Rabin64

### DIFF
--- a/src/rolling_hash.rs
+++ b/src/rolling_hash.rs
@@ -12,6 +12,7 @@ pub trait RollingHash64 {
     fn get_hash(&self) -> &Polynom64;
 }
 
+#[derive(Clone)]
 pub struct Rabin64 {
     // Configuration
     window_size: usize, // The size of the data window used in the hash calculation.


### PR DESCRIPTION
This makes it possible to avoid the initialization of the internal tables when multiple computations are needed.